### PR TITLE
feat: Add Support and FAQ Buttons to Sidebar

### DIFF
--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -1,27 +1,62 @@
 'use client'
 
-import { MdOutlineAdminPanelSettings } from 'react-icons/md'
-
-import { Box, Flex, IconButton, ScrollArea, Text } from '@radix-ui/themes'
+import { Box, Flex, Text } from '@radix-ui/themes'
+import { QuestionMarkIcon } from '@radix-ui/react-icons'
+import { SlSupport } from "react-icons/sl";
 import React, { useContext } from 'react'
 import cs from 'classnames'
-import { useRouter } from 'next/navigation'
 
 import { ChatContext } from '@/components/Chat/context'
-
 import { SideBarChatList } from '@/components/Chat/components/SideBarChatList.component'
 
+/**
+ * SideBar component that displays the chat list and support button.
+ * @returns {JSX.Element} The rendered sidebar component.
+ */
 export const SideBar = () => {
   const { toggleSidebar } = useContext(ChatContext)
 
-  const router = useRouter()
   return (
     <Flex direction="column" className={cs('chart-sider-bar', { show: toggleSidebar })}>
-      <Flex className="p-2 h-full overflow-hidden w-64" direction="column" gap="3">
+      <Flex className="p-2 pb-4 h-full overflow-hidden w-64" direction="column" gap="3">
         <SideBarChatList />
+        <SupportButton />
       </Flex>
     </Flex>
   )
 }
 
 export default SideBar
+
+/**
+ * SupportButton component that opens the default mail client when clicked.
+ * @returns {JSX.Element} The rendered support button component.
+ */
+export const SupportButton = () => {
+  return (
+    <Box
+      width="auto"
+      className="bg-token-surface-primary active:scale-95 cursor-pointer"
+      onClick={() => window.open('mailto:hq-dl-madi@mail.nasa.gov', '_blank')}
+    >
+      <SlSupport />
+      <Text>Support</Text>
+    </Box>
+  )
+}
+
+/**
+ * FAQButton component that displays a FAQs button.
+ * @returns {JSX.Element} The rendered FAQ button component.
+ */
+export const FAQButton = () => {
+  return (
+    <Box
+      width="auto"
+      className="bg-token-surface-primary active:scale-95 cursor-pointer"
+    >
+      <QuestionMarkIcon />
+      <Text>FAQs</Text>
+    </Box>
+  )
+}


### PR DESCRIPTION

### Summary

**Type:** feat

* **What kind of change does this PR introduce?**
  This PR adds new components to the sidebar: a Support button and a FAQ button.

* **What is the current behavior?**
  The current sidebar only displays the chat list without any additional support or FAQ functionalities.

* **What is the new behavior (if this is a feature change)?**
  The sidebar now includes:
  - A Support button that opens the default mail client with a predefined email address when clicked.
  - A FAQ button that displays a FAQs button, though its click functionality is not yet defined.

* **Does this PR introduce a breaking change?**
  No breaking changes introduced. Existing functionalities remain intact.

* **Has Testing been included for this PR?**
  No explicit testing included for this PR.

### Other Information

N/A