### PR TITLE
patch: Remove 'push' Trigger from GitHub Workflows for Lint and Playwright Tests

### DIFF
--- a/.github/workflows/job.lint.yml
+++ b/.github/workflows/job.lint.yml
@@ -1,6 +1,5 @@
 name: Lint
 on: 
-  push:
   workflow_call:
 
 jobs:

--- a/.github/workflows/job.smoke.yml
+++ b/.github/workflows/job.smoke.yml
@@ -1,6 +1,5 @@
 name: Playwright Tests
 on:
-  push:
   workflow_call:    
 
 jobs:


### PR DESCRIPTION

### Summary

**Type:** patch

* **What kind of change does this PR introduce?** 
  Bug fix

* **What is the current behavior?** 
  The GitHub workflows for linting and Playwright tests are triggered on every push to the repository.

* **What is the new behavior (if this is a feature change)?**
  The GitHub workflows will no longer be triggered on push. They will instead rely solely on `workflow_call`.

* **Does this PR introduce a breaking change?** 
  No, it should not require any changes from the users.

* **Has Testing been included for this PR?**
  Not applicable

### Other Information

This PR helps to streamline workflow execution by removing unnecessary triggers and relying on explicit workflow calls.