### PR TITLE
patch: Update GitHub Actions workflow versions and modify conditional branches

### DIFF
--- a/.github/workflows/job.deploy-gcs.yml
+++ b/.github/workflows/job.deploy-gcs.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Authenticate with Google
         uses: 'google-github-actions/auth@v2'
@@ -23,21 +23,21 @@ jobs:
           project_id: ${{ vars.PROJECT_ID }}
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v1
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-
+  
       - name: Install dependencies
-        run: npm ci
+        run: npm ci 
 
       - name: Build the distribution
         run: npm run build; ls -la; pwd;

--- a/.github/workflows/job.lint.yml
+++ b/.github/workflows/job.lint.yml
@@ -8,15 +8,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
-      - name: Download deps
-        uses: bahmutov/npm-install@v1
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci 
 
       - name: Lint
         run: npm run lint:strict
@@ -26,15 +34,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
-      - name: Download deps
-        uses: bahmutov/npm-install@v1
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+              
+      - name: Install dependencies
+        run: npm ci 
 
       - name: Prettier check
         run: npm run format:check

--- a/.github/workflows/job.release.yml
+++ b/.github/workflows/job.release.yml
@@ -16,12 +16,12 @@ jobs:
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/job.smoke.yml
+++ b/.github/workflows/job.smoke.yml
@@ -8,9 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
+
     - name: Cache Node.js modules
       id: cache-node-modules
       uses: actions/cache@v4
@@ -19,8 +21,10 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+
     - name: Install dependencies
       run: npm ci
+
     - name: Cache Playwright browsers
       id: cache-playwright-browsers
       uses: actions/cache@v4
@@ -29,13 +33,16 @@ jobs:
         key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-playwright-
+
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
+      
     - name: Run Playwright tests
       run: npx playwright test
-    - uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+
+    # - uses: actions/upload-artifact@v4
+    #   if: always()
+    #   with:
+    #     name: playwright-report
+    #     path: playwright-report/
+    #     retention-days: 30

--- a/.github/workflows/job.types.yml
+++ b/.github/workflows/job.types.yml
@@ -8,15 +8,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
-      - name: Download deps
-        uses: bahmutov/npm-install@v1
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
+      - name: Install dependencies
+        run: npm ci 
+        
       - name: Lint
         run: npm run lint:types

--- a/.github/workflows/pipeline.deployment.yml
+++ b/.github/workflows/pipeline.deployment.yml
@@ -22,7 +22,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/job.deploy-gcs.yml
   merge-staging:
-    if: github.ref == 'refs/heads/test'
+    if: github.ref == 'refs/heads/develop'
     needs: 
       - deploy
     secrets: inherit
@@ -31,7 +31,7 @@ jobs:
       base-branch: 'test'
       target-branch: 'develop'
   merge-production:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/test'
     needs: 
       - deploy
     secrets: inherit


### PR DESCRIPTION
# patch: Update GitHub Actions workflow versions and modify conditional branches

### Summary

**Type:** patch

* **What kind of change does this PR introduce?**
  - Updates GitHub Actions workflow versions.
  - Modifies conditional branches in deployment workflows.

* **What is the current behavior?**
  - GitHub Actions workflows use older versions.
  - Deployment conditions point to outdated branches.

* **What is the new behavior (if this is a feature change)?**
  - Updated `actions/checkout` to v4.
  - Updated `actions/setup-node` to v4 and Node.js version to 20.
  - Updated `actions/cache` to v4.
  - Commented out `actions/upload-artifact` in smoke test job.
  - Changed deployment conditional branches in `pipeline.deployment.yml`:
    - `merge-staging` triggers on `develop` instead of `test`.
    - `merge-production` triggers on `test` instead of `main`.

* **Does this PR introduce a breaking change?**
  - No breaking changes.

* **Has Testing been included for this PR?**
  - Not applicable; version and config updates.

### Other Information

N/A