### PR TITLE
feat: Add GitHub Action for Linting PR Titles

### DIFF
--- a/.github/workflows/job.lint-pr.yml
+++ b/.github/workflows/job.lint-pr.yml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# feat: Add GitHub Action for Linting PR Titles

### Summary

**Type:** feat

* **What kind of change does this PR introduce?**  
Introduces a new GitHub Action to validate pull request titles.

* **What is the current behavior?**  
No automated validation exists for PR titles.

* **What is the new behavior (if this is a feature change)?**  
A GitHub Action runs on PR events (`opened`, `edited`, `synchronize`), validating PR titles against semantic guidelines.

* **Does this PR introduce a breaking change?**  
No breaking changes.

* **Has Testing been included for this PR?**  
N/A

### Other Information

This action uses `amannn/action-semantic-pull-request@v5` for title validation.