### PR TITLE
ci: Add GitHub Action to Lint PR Titles

### DIFF
--- a/.github/workflows/job.lint-pr.yml
+++ b/.github/workflows/job.lint-pr.yml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-it.js
+++ b/.release-it.js
@@ -62,6 +62,7 @@ module.exports = {
         }
       },
       preset: {
+        // used in the whatBump function above to override defaults
         name: 'conventionalcommits',
         types: [
           {


### PR DESCRIPTION

### Summary

**Type:** ci

* **What kind of change does this PR introduce?** 
  * Introduces a new GitHub Action for PR title validation.

* **What is the current behavior?** 
  * No automated validation of PR titles.

* **What is the new behavior?**
  * GitHub Action enforces semantic PR titles by using the amannn/action-semantic-pull-request action.

* **Does this PR introduce a breaking change?** 
  * No

* **Has Testing been included for this PR?**
  * No explicit tests included. Relying on CI action for validation.

### Other Information

This PR adds a new GitHub Action configuration file, `.github/workflows/job.lint-pr.yml`, which runs title validation on pull request events. Ensures PR titles comply with semantic format.