### PR TITLE
ci: Enhance deployment with multi-branch triggers

### DIFF
--- a/.github/workflows/job.deploy-gcs.yml
+++ b/.github/workflows/job.deploy-gcs.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Build the distribution
         run: npm run build;
 
+      - name: Store release SHA in JSON file
+        run: |
+          mkdir -p ./dist
+          echo '{"sha":"${{ github.sha }}"}' > ./dist/sha.json
+
       - id: 'upload-folder'
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:

--- a/.github/workflows/job.merge.yml
+++ b/.github/workflows/job.merge.yml
@@ -1,4 +1,4 @@
-name: Merge and Tag
+name: Merge
 
 on:
   workflow_call:
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+  actions: write
+  pull-requests: write
 jobs:
   merge:
     runs-on: ubuntu-latest
@@ -33,6 +37,28 @@ jobs:
         git merge --ff-only origin/${{ inputs.target-branch }}
 
     - name: Push changes to ${{ inputs.base-branch }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: success()
       run: |
         git push origin ${{ inputs.base-branch }}
+
+  trigger-push:
+    needs:
+      - merge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger staging deployment
+        run: |
+          set -e
+          
+          response=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/pipeline.deployment.yml/dispatches \
+            -d '{"ref":"${{ inputs.base-branch }}"}')
+          
+          if [[ $response != "204" ]]; then
+            echo "Error: Unexpected response status code $response"
+            exit 1
+          fi

--- a/.github/workflows/pipeline.deployment.yml
+++ b/.github/workflows/pipeline.deployment.yml
@@ -1,28 +1,47 @@
 name: Test and Deploy
 
 on:
-  push: 
+  push:
     branches:
       - 'develop'
-      # - 'test'
-      # - 'production'
-      # - 'main'
-      
+      - 'test'
+      - 'main'
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+        default: 'develop'
+     
+
+# WORKFLOW:
+# -------------------------------------------------
+# PR to develop -> lint -> smoke tests -> deploy -> merge-staging
+# Merge to test -> lint -> smoke tests -> deploy -> release -> merge-production 
+# Merge to main -> lint -> smoke tests -> deploy
+
 jobs:
+
   lint:
     secrets: inherit
     uses: ./.github/workflows/job.lint.yml
+
   smoke-tests:
     secrets: inherit
     uses: ./.github/workflows/job.smoke.yml
+
   deploy:
     needs: 
       - lint
       - smoke-tests
     secrets: inherit
-    uses: ./.github/workflows/job.deploy-gcs.yml
+    uses: ./.github/workflows/job.deploy-gcs.yml  
+
+
+  ## ONLY ON DEVELOP
   merge-staging:
-    # if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop'
     needs: 
       - deploy
     secrets: inherit
@@ -30,16 +49,21 @@ jobs:
     with:
       base-branch: 'test'
       target-branch: 'develop'
-  merge-production:
+
+
+  ## ONLY ON TEST
+  release:
+    if: github.ref == 'refs/heads/test'
     needs: 
-      - merge-staging
+      - deploy
+    secrets: inherit
+    uses: ./.github/workflows/job.release.yml
+  merge-production:
+    if: github.ref == 'refs/heads/test'
+    needs: 
+      - deploy
     secrets: inherit
     uses: ./.github/workflows/job.merge.yml
     with:
       base-branch: 'main'
       target-branch: 'test'
-  release:
-    needs: 
-      - merge-production
-    secrets: inherit
-    uses: ./.github/workflows/job.release.yml

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ next-env.d.ts
 
 # JetBrains
 .idea/
+
+/test-results
+/playwright-report
 trace.zip
 .last-run.json
 createrelease.sh


### PR DESCRIPTION

### Summary

**Type:** ci

* **What kind of change does this PR introduce?** 
  * Updates the deployment and merge workflows in GitHub Actions.

* **What is the current behavior?** 
  * Lacks storing SHA in the distribution and explicit permissions in workflows.
  * Simplified workflow steps for merging and tagging.

* **What is the new behavior?**
  * Adds a step to store the release SHA in JSON file during deployment.
  * Renames "Merge and Tag" workflow to "Merge".
  * Grants explicit permissions for contents, actions, and pull-requests.
  * Introduces `trigger-push` step to trigger the staging deployment post-merge.
  * Updates deployment workflow to include releases for `test` and adds `workflow_dispatch` and `workflow_call`.
  * Merges to `main` branch after deploying from `test` branch.

* **Does this PR introduce a breaking change?** 
  * No.

* **Has Testing been included for this PR?**
  * No explicit tests are mentioned, but GitHub Actions workflows will be tested implicitly through usage.

### Other Information

Added entries `/test-results` and `/playwright-report` to `.gitignore` to exclude test artifacts from version control.