### PR TITLE
ci: Update GCS deployment workflow to dynamically set repo name

### DIFF
--- a/.github/workflows/job.deploy-gcs.yml
+++ b/.github/workflows/job.deploy-gcs.yml
@@ -53,15 +53,17 @@ jobs:
       
       - name: Build the distribution
         run: npm run build;
-      
+
+        
       - name: Store release SHA in JSON file
         run: |
           mkdir -p ./dist
+          REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
           echo '{
             "sha": "${{ github.sha }}",
-            "owner": ${{ github.repository_owner }},
-            "repo": ${{github.repository}},
-            "branch": ${{ github.ref_name }}
+            "owner": "${{ github.repository_owner }}",
+            "repo": "'$REPO_NAME'",
+            "branch": "${{ github.ref_name }}"
           }' > ./dist/sha.json
 
       - id: 'upload-folder'


### PR DESCRIPTION

### Summary

**Type:** ci

* **What kind of change does this PR introduce?**  
  Improvement in the CI workflow for deploying to GCS.

* **What is the current behavior?**  
  The repository name is directly taken from `${{ github.repository }}` which includes both the owner and the repo name.

* **What is the new behavior?**  
  The repository name is now dynamically extracted using a shell command to separate it from the owner. This provides more precise information for the `repo` field in the generated JSON file.

* **Does this PR introduce a breaking change?**  
  No.

* **Has Testing been included for this PR?**
  No additional testing required as this is a minor change in a CI workflow script.

### Other Information

This change ensures that the JSON file generated during the deployment process contains only the repo name without the owner prefix. This can help standardize the format of the JSON file across different workflows.