### PR TITLE
fix: Properly handle empty tools array in postChat function

### DIFF
--- a/components/getResponse.ts
+++ b/components/getResponse.ts
@@ -159,8 +159,8 @@ export const postChat = async (
     body: JSON.stringify({
       stream: true,
       messages: [{ role: 'system', content: systemPrompt }, ...messageArray!],
-      tools: tools ? tools : undefined,
-      tool_choice: tools ? tool_choice : undefined
+      tools: tools?.length ? tools : undefined,
+      tool_choice: tools?.length ? tool_choice : undefined
     })
   })
 


### PR DESCRIPTION

### Summary

**Type:** fix

* **What kind of change does this PR introduce?**
  * Bug fix

* **What is the current behavior?**
  * The `postChat` function incorrectly adds `tools` and `tool_choice` properties to the request body even if the `tools` array is empty.

* **What is the new behavior?**
  * The `postChat` function now checks if the `tools` array has a length before adding `tools` and `tool_choice` properties, ensuring these properties are only included when the `tools` array is non-empty.

* **Does this PR introduce a breaking change?**
  * No

* **Has Testing been included for this PR?**
  * Not specified in the diff

### Other Information

N/A